### PR TITLE
Fix show context toggle

### DIFF
--- a/src/gui/card-ui.tsx
+++ b/src/gui/card-ui.tsx
@@ -380,9 +380,11 @@ export class CardUI {
         this.currentDeckCardCounterIcon.addClass("sr-current-deck-card-counter-icon");
         setIcon(this.currentDeckCardCounterIcon, "credit-card");
 
-        if (this.settings.showContextInCards) {
-            this.cardContext = this.infoSection.createDiv();
-            this.cardContext.addClass("sr-context");
+        // Always create the card context element to avoid undefined errors
+        this.cardContext = this.infoSection.createDiv();
+        this.cardContext.addClass("sr-context");
+        if (!this.settings.showContextInCards) {
+            this.cardContext.addClass("sr-is-hidden");
         }
     }
 
@@ -440,9 +442,20 @@ export class CardUI {
     }
 
     private _updateCardContext() {
+        if (!this.cardContext) {
+            return;
+        }
+
         if (!this.settings.showContextInCards) {
             this.cardContext.setText("");
+            if (!this.cardContext.hasClass("sr-is-hidden")) {
+                this.cardContext.addClass("sr-is-hidden");
+            }
             return;
+        }
+
+        if (this.cardContext.hasClass("sr-is-hidden")) {
+            this.cardContext.removeClass("sr-is-hidden");
         }
         this.cardContext.setText(
             ` ${this._formatQuestionContextText(this._currentQuestion.questionContext)}`,


### PR DESCRIPTION
## Summary
- always create a `cardContext` element in the info bar
- hide or show the context element when toggling the setting

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/...)*

------
https://chatgpt.com/codex/tasks/task_e_68783c68d4708333b6be30ead5c5bbae